### PR TITLE
Fix default set of cops in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ inherit_gem:
 ```yaml
 inherit_gem:
   theforeman-rubocop:
-    - all.yml
+    - default.yml
 ```
 
 ### All cops, including newly introduced ones


### PR DESCRIPTION
That was the idea I guess. Honestly I'd rather see levels instead of all/default: loose, tighen, very tight or something like that.