### PR TITLE
Upgrade RuboCop version to 1.60.0

### DIFF
--- a/rules/minitest.yml
+++ b/rules/minitest.yml
@@ -3,3 +3,6 @@ require:
 
 Minitest/MultipleAssertions:
   Max: 5
+
+Minitest/TestFileName:
+  Enabled: true

--- a/rules/rails.yml
+++ b/rules/rails.yml
@@ -2,7 +2,7 @@ require:
   - rubocop-rails
 
 AllCops:
-  TargetRailsVersion: 6.0
+  TargetRailsVersion: 6.1
 
 Rails:
   Enabled: true

--- a/rules/rails.yml
+++ b/rules/rails.yml
@@ -1,5 +1,6 @@
 require:
   - rubocop-rails
+  - rubocop-factory_bot
 
 AllCops:
   TargetRailsVersion: 6.1

--- a/rules/ruby_target.yml
+++ b/rules/ruby_target.yml
@@ -1,2 +1,2 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7

--- a/theforeman-rubocop.gemspec
+++ b/theforeman-rubocop.gemspec
@@ -1,4 +1,4 @@
-# coding: utf-8
+# frozen_string_literal: true
 
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
@@ -16,17 +16,19 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 1.23.0'
-  spec.add_dependency 'rubocop-checkstyle_formatter', '~> 0.4.0'
-  spec.add_dependency 'rubocop-rspec', '~> 2.0'
-  spec.add_dependency 'rubocop-minitest', '~> 0.17.0'
-  spec.add_dependency 'rubocop-performance', '~> 1.8.1'
-  spec.add_dependency 'rubocop-rails', '~> 2.12.4'
-  spec.add_dependency 'rubocop-graphql', '~> 0.11.2'
-  spec.add_development_dependency 'bundler', '~> 2.1'
-  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.required_ruby_version = '>= 2.7', '< 4'
+
+  spec.add_dependency 'rubocop', '~> 1.64.0'
+  spec.add_dependency 'rubocop-checkstyle_formatter', '~> 0.6.0'
+  spec.add_dependency 'rubocop-graphql', '~> 1.4.0'
+  spec.add_dependency 'rubocop-minitest', '~> 0.33.0'
+  spec.add_dependency 'rubocop-performance', '~> 1.19.0'
+  spec.add_dependency 'rubocop-rails', '~> 2.22.0'
+  spec.add_dependency 'rubocop-rspec', '~> 2.25.0'
+  spec.add_development_dependency 'bundler', '~> 2.4', '>= 2.4.22'
+  spec.add_development_dependency 'rake', '~> 13.0', '>= 13.1.0'
 end


### PR DESCRIPTION
This is part of Rubocop standerdization, link for the reference: https://community.theforeman.org/t/standardizing-rubocop-with-theforeman-rubocop/37239