### PR TITLE
Add RuboCop extensions: rubocop-capybara and rubocop-graphql

### DIFF
--- a/rules/rails.yml
+++ b/rules/rails.yml
@@ -1,6 +1,8 @@
 require:
   - rubocop-rails
   - rubocop-factory_bot
+  - rubocop-capybara
+  - rubocop-graphql
 
 AllCops:
   TargetRailsVersion: 6.1


### PR DESCRIPTION
Updated `/rules/rails.yml` to include the `rubocop-capybara` and `rubocop-graphql` extensions in the configuration.

Based on conversation: https://github.com/theforeman/theforeman-rubocop/issues/13#issuecomment-2317256054