### PR TITLE
Add versioning-strategy: increase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  versioning-strategy: increase


### PR DESCRIPTION
This PR adds `versioning-strategy: increase` to the dependabot.yml configuration. This change is enforce to pin to y-stream, ensuring that dependabot only suggests updates within the existing version constraints.